### PR TITLE
113-do-not-log-user-entry-errors-in-sentry

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -4,12 +4,15 @@ import sentry_sdk
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from app.utils.general_utils import sentry_filter_transactions
+
 from .core.settings import app_settings
 from .routers import applications, awards, borrowers, lenders, users
 
 if app_settings.sentry_dsn:
     sentry_sdk.init(
         dsn=app_settings.sentry_dsn,
+        before_send=sentry_filter_transactions,
         # Set traces_sample_rate to 1.0 to capture 100% of transactions for performance monitoring.
         traces_sample_rate=1.0,
     )

--- a/app/utils/general_utils.py
+++ b/app/utils/general_utils.py
@@ -23,9 +23,8 @@ def update_models_with_validation(payload, model):
 
 
 def sentry_filter_transactions(event, hint):
-    try:
-        data_url = event["breadcrumbs"]["values"][0]["data"]["url"]
-        if re.search(r"https://cognito-idp.*\.amazonaws\.com", data_url):
-            return None
-    except:
-        return event
+    data_url = event["breadcrumbs"]["values"][0]["data"]["url"] or None
+    if data_url and re.search(r"https://cognito-idp.*\.amazonaws\.com", data_url):
+        return None
+
+    return event

--- a/app/utils/general_utils.py
+++ b/app/utils/general_utils.py
@@ -1,3 +1,5 @@
+import re
+
 from fastapi import HTTPException, status
 from fastapi.encoders import jsonable_encoder
 
@@ -18,3 +20,12 @@ def update_models_with_validation(payload, model):
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                 detail="This column cannot be updated",
             )
+
+
+def sentry_filter_transactions(event, hint):
+    try:
+        data_url = event["breadcrumbs"]["values"][0]["data"]["url"]
+        if re.search(r"https://cognito-idp.*\.amazonaws\.com", data_url):
+            return None
+    except:
+        return event


### PR DESCRIPTION
- added filter for cognito events so they wont be tracked in sentry. Any other filter we may neeed can be added on top of this one