### PR TITLE
120 check preferences before sending emails

### DIFF
--- a/app/background_processes/application_utils.py
+++ b/app/background_processes/application_utils.py
@@ -199,6 +199,7 @@ def get_applications_to_remind_intro():
                         <= datetime.now()
                         + timedelta(days=app_settings.reminder_days_before_expiration),
                         ~core.Application.id.in_(subquery),
+                        core.Borrower.status == core.BorrowerStatus.ACTIVE,
                     )
                 )
                 .all()

--- a/app/background_processes/fetcher.py
+++ b/app/background_processes/fetcher.py
@@ -30,6 +30,12 @@ def fetch_new_awards_from_date(last_updated_award_date: str, email_invitation: s
                     borrower = get_or_create_borrower(entry, session)
                     award.borrower_id = borrower.id
 
+                    if borrower.status == BorrowerStatus.DECLINE_OPPORTUNITIES:
+                        logging.info(
+                            "Borrower chose to not receive new oportunities. Skipping app creation."
+                        )
+                        continue
+
                     application = create_application(
                         award.id,
                         borrower.id,
@@ -38,12 +44,6 @@ def fetch_new_awards_from_date(last_updated_award_date: str, email_invitation: s
                         award.source_contract_id,
                         session,
                     )
-
-                    if borrower.status == BorrowerStatus.DECLINE_OPPORTUNITIES:
-                        logging.info(
-                            "Borrower chose to not receive new oportunities. Skipping notification"
-                        )
-                        continue
 
                     message = insert_message(application, session)
 

--- a/app/background_processes/fetcher.py
+++ b/app/background_processes/fetcher.py
@@ -4,7 +4,7 @@ from contextlib import contextmanager
 from app.core.settings import app_settings
 from app.core.user_dependencies import sesClient
 from app.db.session import get_db
-from app.schema.core import Borrower
+from app.schema.core import Borrower, BorrowerStatus
 from app.utils import email_utility
 
 from . import awards_utils
@@ -38,6 +38,12 @@ def fetch_new_awards_from_date(last_updated_award_date: str, email_invitation: s
                         award.source_contract_id,
                         session,
                     )
+
+                    if borrower.status == BorrowerStatus.DECLINE_OPPORTUNITIES:
+                        logging.info(
+                            "Borrower chose to not receive new oportunities. Skipping notification"
+                        )
+                        continue
 
                     message = insert_message(application, session)
 


### PR DESCRIPTION
fix: now we check if borrower chose not to receive new notifications when creating a new app and sending reminders

