### PR TITLE
114 new application email to fi error

### DIFF
--- a/app/utils/email_utility.py
+++ b/app/utils/email_utility.py
@@ -311,7 +311,7 @@ def send_notification_new_app_to_ocp(ses, ocp_email_group, lender_name):
 
     data = {
         **generate_common_data(),
-        "F1": lender_name,
+        "FI": lender_name,
         "LOGIN_URL": app_settings.frontend_url + "/login",
         "LOGIN_IMAGE_LINK": images_base_url + "/logincompleteimage.png",
     }


### PR DESCRIPTION
fix: typo in send_notification_new_app_to_ocp corrected
Templates with F1 instead of Fi were corrected in branch 43