### PR TITLE
Refactor type hints and fix related bugs

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -1,6 +1,6 @@
 import requests
 from fastapi import HTTPException, Request, status
-from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from fastapi.security import HTTPBearer
 from jose import JWTError, jwk, jwt
 from jose.utils import base64url_decode
 from pydantic import BaseModel
@@ -66,7 +66,7 @@ class verifyTokeClass(HTTPBearer):
         :return: JWT credentials if the token is verified.
         """
         self.load_keys()
-        credentials: HTTPAuthorizationCredentials = await super().__call__(request)
+        credentials = await super().__call__(request)
 
         if credentials:
             if not credentials.scheme == "Bearer":

--- a/app/aws.py
+++ b/app/aws.py
@@ -37,12 +37,6 @@ def generate_password_fn() -> str:
 class CognitoClient:
     """
     A client for AWS Cognito and SES services.
-
-    Attributes:
-        client: A boto3 client for Cognito
-        ses: A boto3 client for SES
-        generate_password: A function reference that generates a password
-
     """
 
     def __init__(
@@ -51,8 +45,11 @@ class CognitoClient:
         sesClient,
         generate_password_fn,
     ):
+        #: A boto3 client for Cognito
         self.client = cognitoClient
+        #: A boto3 client for SES
         self.ses = sesClient
+        #: A function reference that generates a password
         self.generate_password = generate_password_fn
 
     def exceptions(self):
@@ -62,11 +59,8 @@ class CognitoClient:
         """
         Generates a secret hash for the given username using Cognito client secret and Cognito client id.
 
-        Args:
-            username: A string containing the username
-
-        Returns:
-            A base64 encoded string containing the generated secret hash.
+        :param username: A string containing the username
+        :return: A base64 encoded string containing the generated secret hash.
         """
         app_client_id = app_settings.cognito_client_id
         key = app_settings.cognito_client_secret
@@ -79,15 +73,10 @@ class CognitoClient:
         Creates a new user in AWS Cognito with the specified username and name. Sends an email to the new user
         with their temporary password.
 
-        Args:
-            username: A string containing the username of the new user (email format is expected).
-            name: A string containing the name of the new user.
-
-        Returns:
-            A dictionary containing the response from the Cognito 'admin_create_user' method.
-
-        Raises:
-            boto3.exceptions: Any exceptions that occur when making the Cognito 'admin_create_user' request or sending the email. # noqa
+        :param username: A string containing the username of the new user (email format is expected).
+        :param name: A string containing the name of the new user.
+        :return: A dictionary containing the response from the Cognito 'admin_create_user' method.
+        :raises boto3.exceptions: Any exceptions that occur when making the Cognito request or sending the email.
         """
         temp_password = self.generate_password()
 
@@ -107,14 +96,9 @@ class CognitoClient:
         """
         Verifies the email of a user in AWS Cognito.
 
-        Args:
-            username: A string containing the username (email) of the user.
-
-        Returns:
-            A dictionary containing the response from the Cognito 'admin_update_user_attributes' method.
-
-        Raises:
-            boto3.exceptions: Any exceptions that occur when making the Cognito 'admin_update_user_attributes' request.
+        :param username: A string containing the username (email) of the user.
+        :return: A dictionary containing the response from the Cognito 'admin_update_user_attributes' method.
+        :raises boto3.exceptions: Any exceptions that occur when making the Cognito request.
         """
         response = self.client.admin_update_user_attributes(
             UserPoolId=app_settings.cognito_pool_id,
@@ -130,19 +114,15 @@ class CognitoClient:
         """
         Initiates an authentication request for a user in AWS Cognito.
 
-        Args:
-            username: A string containing the username (typically an email) of the user initiating the authentication.
-            password: A string containing the password of the user initiating the authentication.
-
-        Returns:
-            A dictionary containing the response from the Cognito 'initiate_auth' method, which includes the session expiration time if the authentication is successful. # noqa
-
-        Raises:
-            boto3.exceptions: Any exceptions that occur when making the Cognito 'initiate_auth' request.
+        :param username: A string containing the username (typically an email) of the user initiating authentication.
+        :param password: A string containing the password of the user initiating the authentication.
+        :return: A dictionary containing the response from the Cognito 'initiate_auth' method, which includes the
+                 session expiration time if the authentication is successful.
+        :raises boto3.exceptions: Any exceptions that occur when making the Cognito request.
 
         Notes:
-            The 'initiate_auth' method uses 'USER_PASSWORD_AUTH' as the authentication flow, which requires a USERNAME, PASSWORD, and SECRET_HASH. # noqa
-            The SECRET_HASH is generated using the 'get_secret_hash' method of this class.
+            The 'initiate_auth' method uses 'USER_PASSWORD_AUTH' as the authentication flow, which requires a USERNAME,
+            PASSWORD, and SECRET_HASH. The SECRET_HASH is generated using the 'get_secret_hash' method of this class.
         """
         secret_hash = self.get_secret_hash(username)
         response = self.client.initiate_auth(
@@ -168,17 +148,13 @@ class CognitoClient:
         """
         Sets up multi-factor authentication (MFA) for a user in AWS Cognito.
 
-        Args:
-            session: A string representing the session in which the user is currently authenticated.
-
-        Returns:
-            A dictionary containing a secret code for the Google Authenticator application and the updated session ID.
-
-        Raises:
-            boto3.exceptions: Any exceptions that occur when making the Cognito 'associate_software_token' request.
+        :param session: A string representing the session in which the user is currently authenticated.
+        :return: A dictionary containing a secret code for the Google Authenticator app and the updated session ID.
+        :raises boto3.exceptions: Any exceptions that occur when making the Cognito request.
 
         Notes:
-            The 'associate_software_token' method generates a secret code that is used to associate the user's AWS Cognito account with a multi-factor authentication app, such as Google Authenticator. # noqa
+            The 'associate_software_token' method generates a secret code that is used to associate the user's AWS
+            Cognito account with a multi-factor authentication app, such as Google Authenticator.
         """
         response = self.client.associate_software_token(Session=session)
         # Use this code in cmd to associate google authenticator with you account
@@ -191,19 +167,15 @@ class CognitoClient:
         """
         Verifies a multi-factor authentication (MFA) code entered by the user in AWS Cognito.
 
-        Args:
-            access_token: A string representing the access token of the authenticated user.
-            session: A string representing the session in which the user is currently authenticated.
-            mfa_code: A string representing the MFA code that was entered by the user.
-
-        Returns:
-            A dictionary containing the response from the Cognito 'verify_software_token' method.
-
-        Raises:
-            boto3.exceptions: Any exceptions that occur when making the Cognito 'verify_software_token' request.
+        :param access_token: A string representing the access token of the authenticated user.
+        :param session: A string representing the session in which the user is currently authenticated.
+        :param mfa_code: A string representing the MFA code that was entered by the user.
+        :return: A dictionary containing the response from the Cognito 'verify_software_token' method.
+        :raises boto3.exceptions: Any exceptions that occur when making the Cognito request.
 
         Notes:
-            The 'verify_software_token' method validates the MFA code provided by the user. If the code is valid, the method will return a successful response. # noqa
+            The 'verify_software_token' method validates the MFA code provided by the user. If the code is valid, the
+            method will return a successful response.
         """
         response = self.client.verify_software_token(AccessToken=access_token, Session=session, UserCode=mfa_code)
 
@@ -213,21 +185,19 @@ class CognitoClient:
         """
         Responds to the authentication challenge provided by AWS Cognito.
 
-        Args:
-            username: A string containing the username (email) of the user.
-            session: A string representing the session in which the user is currently authenticated.
-            challenge_name: A string representing the name of the challenge to respond to.
-            new_password: A string containing the new password of the user. This is required if the challenge is 'NEW_PASSWORD_REQUIRED'.
-            mfa_code: A string representing the MFA code that was entered by the user. This is required if the challenge is 'MFA_SETUP' or 'SOFTWARE_TOKEN_MFA'.# noqa
-
-        Returns:
-            A dictionary containing the response from the Cognito 'respond_to_auth_challenge' method.
-
-        Raises:
-            boto3.exceptions: Any exceptions that occur when making the Cognito 'respond_to_auth_challenge' request.
+        :param username: A string containing the username (email) of the user.
+        :param session: A string representing the session in which the user is currently authenticated.
+        :param challenge_name: A string representing the name of the challenge to respond to.
+        :param new_password: A string containing the new password of the user. This is required if the challenge is
+                             'NEW_PASSWORD_REQUIRED'.
+        :param mfa_code: A string representing the MFA code that was entered by the user. This is required if the
+                         challenge is 'MFA_SETUP' or 'SOFTWARE_TOKEN_MFA'.
+        :return: A dictionary containing the response from the Cognito 'respond_to_auth_challenge' method.
+        :raises boto3.exceptions: Any exceptions that occur when making the Cognito request.
 
         Notes:
-            The 'respond_to_auth_challenge' method allows the application to respond to different types of authentication challenges issued by AWS Cognito. # noqa
+            The 'respond_to_auth_challenge' method allows the application to respond to different types of
+            authentication challenges issued by AWS Cognito.
         """
         secret_hash = self.get_secret_hash(username)
         if challenge_name == "NEW_PASSWORD_REQUIRED":
@@ -279,17 +249,14 @@ class CognitoClient:
         """
         Logs out a user from all devices in AWS Cognito.
 
-        Args:
-            access_token: A string representing the access token of the user to log out.
-
-        Returns:
-            A dictionary containing the response from the Cognito 'admin_user_global_sign_out' method.
-
-        Raises:
-            boto3.exceptions: Any exceptions that occur when making the Cognito 'admin_user_global_sign_out' request.
+        :param access_token: A string representing the access token of the user to log out.
+        :return: A dictionary containing the response from the Cognito 'admin_user_global_sign_out' method.
+        :raises boto3.exceptions: Any exceptions that occur when making the Cognito request.
 
         Notes:
-            The 'admin_user_global_sign_out' method invalidates all refresh tokens issued to a user, which are required for the user to maintain access to authorized resources. The method should be used when the user logs out and chooses to log out from all devices. # noqa
+            The 'admin_user_global_sign_out' method invalidates all refresh tokens issued to a user, which are required
+            for the user to maintain access to authorized resources. The method should be used when the user logs out
+            and chooses to log out from all devices.
         """
         response = self.client.get_user(AccessToken=access_token)
         username = None
@@ -305,17 +272,11 @@ class CognitoClient:
         """
         Resets the user's password.
 
-        Args:
-            username: A string containing the username (email) of the user.
+        An email is sent to the user with the new temporary password.
 
-        Returns:
-            A dictionary containing the response from the Cognito 'admin_set_user_password' method.
-
-        Side Effects:
-            An email is sent to the user with the new temporary password.
-
-        Raises:
-            boto3.exceptions: Any exceptions that occur when making the Cognito 'admin_set_user_password' request.
+        :param username: A string containing the username (email) of the user.
+        :return: A dictionary containing the response from the Cognito 'admin_set_user_password' method.
+        :raises boto3.exceptions: Any exceptions that occur when making the Cognito request.
         """
         temp_password = self.generate_password()
 
@@ -338,16 +299,12 @@ class CognitoClient:
         """
         Sends notifications of new applications.
 
-        Args:
-            ocp_email_group: A list of email addresses representing the OCP email group.
-            lender_name: A string representing the lender's name.
-            lender_email_group: A list of email addresses representing the lender's email group.
+        Sends an email notification to the lender's email group and to the OCP email group about the new application.
 
-        Side Effects:
-            Sends an email notification to the lender's email group and to the OCP email group about the new application. # noqa
-
-        Raises:
-            boto3.exceptions: Any exceptions that occur when sending the emails.
+        :param ocp_email_group: A list of email addresses representing the OCP email group.
+        :param lender_name: A string representing the lender's name.
+        :param lender_email_group: A list of email addresses representing the lender's email group.
+        :raises boto3.exceptions: Any exceptions that occur when sending the emails.
         """
         mail.send_notification_new_app_to_fi(self.ses, lender_email_group)
         mail.send_notification_new_app_to_ocp(self.ses, ocp_email_group, lender_name)
@@ -356,17 +313,12 @@ class CognitoClient:
         """
         Sends a request to the SME via email.
 
-        Args:
-            uuid: A string representing the unique identifier of the request.
-            lender_name: A string representing the name of the lender.
-            email_message: A string containing the email message to be sent.
-            sme_email: A string representing the SME's email address.
-
-        Returns:
-            A string representing the message id of the sent email.
-
-        Raises:
-            boto3.exceptions: Any exceptions that occur when sending the email.
+        :param uuid: A string representing the unique identifier of the request.
+        :param lender_name: A string representing the name of the lender.
+        :param email_message: A string containing the email message to be sent.
+        :param sme_email: A string representing the SME's email address.
+        :return: A string representing the message id of the sent email.
+        :raises boto3.exceptions: Any exceptions that occur when sending the email.
         """
         message_id = mail.send_mail_request_to_sme(self.ses, uuid, lender_name, email_message, sme_email)
         return message_id
@@ -375,15 +327,10 @@ class CognitoClient:
         """
         Sends a rejection email to the SME, potentially with alternatives.
 
-        Args:
-            application: An object representing the application details.
-            options: A boolean indicating if alternatives should be included in the rejection email.
-
-        Returns:
-            A string representing the message id of the sent email.
-
-        Raises:
-            boto3.exceptions: Any exceptions that occur when sending the email.
+        :param application: An object representing the application details.
+        :param options: A boolean indicating if alternatives should be included in the rejection email.
+        :return: A string representing the message id of the sent email.
+        :raises boto3.exceptions: Any exceptions that occur when sending the email.
         """
         if options:
             message_id = mail.send_rejected_application_email(self.ses, application)
@@ -395,14 +342,9 @@ class CognitoClient:
         """
         Sends a approved confirmation email to the SME.
 
-        Args:
-            application: An object representing the application details.
-
-        Returns:
-            A string representing the message id of the sent email.
-
-        Raises:
-            boto3.exceptions: Any exceptions that occur when sending the email.
+        :param application: An object representing the application details.
+        :return: A string representing the message id of the sent email.
+        :raises boto3.exceptions: Any exceptions that occur when sending the email.
         """
         message_id = mail.send_application_approved_email(self.ses, application)
         return message_id
@@ -411,14 +353,9 @@ class CognitoClient:
         """
         Sends a submission confirmation email to the SME.
 
-        Args:
-            application: An object representing the application details.
-
-        Returns:
-            A string representing the message id of the sent email.
-
-        Raises:
-            boto3.exceptions: Any exceptions that occur when sending the email.
+        :param application: An object representing the application details.
+        :return: A string representing the message id of the sent email.
+        :raises boto3.exceptions: Any exceptions that occur when sending the email.
         """
         message_id = mail.send_application_submission_completed(self.ses, application)
         return message_id
@@ -427,14 +364,9 @@ class CognitoClient:
         """
         Sends a credit disbursed confirmation email to the SME.
 
-        Args:
-            application: An object representing the application details.
-
-        Returns:
-            A string representing the message id of the sent email.
-
-        Raises:
-            boto3.exceptions: Any exceptions that occur when sending the email.
+        :param application: An object representing the application details.
+        :return: A string representing the message id of the sent email.
+        :raises boto3.exceptions: Any exceptions that occur when sending the email.
         """
         message_id = mail.send_application_credit_disbursed(self.ses, application)
         return message_id
@@ -450,18 +382,13 @@ class CognitoClient:
         """
         Sends an email confirmation message to a SME for a new email.
 
-        Args:
-            borrower_name: A string representing the name of the borrower.
-            new_email: A string representing the new email address to be confirmed.
-            old_email: A string representing the old email address.
-            confirmation_email_token: A string representing the email confirmation token.
-            application_uuid: A string representing the UUID of the application.
-
-        Returns:
-            A string representing the message id of the sent email.
-
-        Raises:
-            boto3.exceptions: Any exceptions that occur when sending the email.
+        :param borrower_name: A string representing the name of the borrower.
+        :param new_email: A string representing the new email address to be confirmed.
+        :param old_email: A string representing the old email address.
+        :param confirmation_email_token: A string representing the email confirmation token.
+        :param application_uuid: A string representing the UUID of the application.
+        :return: A string representing the message id of the sent email.
+        :raises boto3.exceptions: Any exceptions that occur when sending the email.
         """
         return mail.send_new_email_confirmation(
             self.ses,
@@ -476,14 +403,9 @@ class CognitoClient:
         """
         Sends upload contract notifications to both the Financial Institution (FI) and the SME.
 
-        Args:
-            application: An application object containing details of the application.
-
-        Returns:
-            A tuple containing the message ids of the sent notifications, in the order: (FI_message_id, SME_message_id)
-
-        Raises:
-            boto3.exceptions: Any exceptions that occur when sending the notifications.
+        :param application: An application object containing details of the application.
+        :return: A tuple containing the message ids of the sent notifications: (FI_message_id, SME_message_id)
+        :raises boto3.exceptions: Any exceptions that occur when sending the notifications.
         """
         FI_message_id = mail.send_upload_contract_notification_to_FI(
             self.ses,
@@ -500,14 +422,9 @@ class CognitoClient:
         """
         Sends upload documents notifications to the Financial Institution (FI).
 
-        Args:
-            email: A string containing the email address where the notification will be sent.
-
-        Returns:
-            A string representing the message id of the sent notification.
-
-        Raises:
-            boto3.exceptions: Any exceptions that occur when sending the notification.
+        :param email: A string containing the email address where the notification will be sent.
+        :return: A string representing the message id of the sent notification.
+        :raises boto3.exceptions: Any exceptions that occur when sending the notification.
         """
         message_id = mail.send_upload_documents_notifications_to_FI(
             self.ses,
@@ -519,14 +436,9 @@ class CognitoClient:
         """
         Sends copied application notifications to the SME.
 
-        Args:
-            application: An application object containing information about the application that has been copied.
-
-        Returns:
-            A string representing the message id of the sent notification.
-
-        Raises:
-            boto3.exceptions: Any exceptions that occur when sending the notification.
+        :param application: An application object containing information about the application that has been copied.
+        :return: A string representing the message id of the sent notification.
+        :raises boto3.exceptions: Any exceptions that occur when sending the notification.
         """
         return mail.send_copied_application_notification_to_sme(
             self.ses,

--- a/app/aws.py
+++ b/app/aws.py
@@ -4,6 +4,7 @@ import hmac
 import logging
 import random
 import string
+from typing import Any
 
 import boto3
 
@@ -110,7 +111,7 @@ class CognitoClient:
 
         return response
 
-    def initiate_auth(self, username, password):
+    def initiate_auth(self, username, password) -> dict[str, Any]:
         """
         Initiates an authentication request for a user in AWS Cognito.
 

--- a/app/db.py
+++ b/app/db.py
@@ -15,7 +15,7 @@ SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 
 @contextmanager
-def transaction_session(db: Session):
+def transaction_session(db: Session) -> Generator[Session, None, None]:
     """
     Context manager for database transactions. It takes a Session instance, commits the transaction if it is successful, # noqa
     and rolls back the transaction if any exception is raised.
@@ -33,7 +33,7 @@ def transaction_session(db: Session):
 
 
 @contextmanager
-def transaction_session_logger(session: Session, msg: str, *args):
+def transaction_session_logger(session: Session, msg: str, *args) -> Generator[Session, None, None]:
     try:
         yield session
         session.commit()
@@ -46,7 +46,7 @@ def transaction_session_logger(session: Session, msg: str, *args):
         session.rollback()
 
 
-def get_db() -> Generator:
+def get_db() -> Generator[Session, None, None]:
     """
     Generator function to get a new database session. Yields a database session instance and closes the session after
     it is used.

--- a/app/db.py
+++ b/app/db.py
@@ -10,13 +10,8 @@ from app.settings import app_settings
 
 logger = logging.getLogger(__name__)
 
-SessionLocal = None
-if app_settings.database_url:
-    engine = create_engine(app_settings.database_url)
-    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-if app_settings.test_database_url:
-    engine = create_engine(app_settings.test_database_url)
-    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+engine = create_engine(app_settings.test_database_url if app_settings.test_database_url else app_settings.database_url)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 
 @contextmanager
@@ -59,11 +54,7 @@ def get_db() -> Generator:
     :return: The database session instance.
     """
     try:
-        db = None
-        if SessionLocal:
-            db = SessionLocal()
-
+        db = SessionLocal()
         yield db
     finally:
-        if db:
-            db.close()
+        db.close()

--- a/app/mail.py
+++ b/app/mail.py
@@ -126,7 +126,6 @@ def generate_common_data() -> dict:
 
     :return: Returns a dictionary containing the frontend URL, URLs of various logos and social media links.
     """
-
     return {
         "OCP_LOGO": app_settings.images_base_url + "/logoocp.jpg",
         "TWITTER_LOGO": app_settings.images_base_url + "/twiterlogo.png",
@@ -148,7 +147,6 @@ def get_images_base_url() -> str:
 
     :return: Returns the base URL for images.
     """
-
     images_base_url = app_settings.images_base_url
     if app_settings.email_template_lang != "":
         images_base_url = f"{images_base_url}/{app_settings.email_template_lang}"
@@ -208,7 +206,6 @@ def send_application_approved_email(ses: SESClient, application: Application):
     :param ses: SES client instance used to send emails.
     :param application: The application object which has been approved.
     """
-
     images_base_url = get_images_base_url()
     html_data = {
         "FI": application.lender.name,
@@ -218,9 +215,8 @@ def send_application_approved_email(ses: SESClient, application: Application):
         "UPLOAD_CONTRACT_URL": f"{app_settings.frontend_url}/application/{quote(application.uuid)}/upload-contract",
         "UPLOAD_CONTRACT_IMAGE_LINK": f"{images_base_url}/uploadContract.png",
     }
-    data = prepare_html("Application_approved", html_data)
 
-    send_email(ses, application.primary_email, data)
+    send_email(ses, application.primary_email, prepare_html("Application_approved", html_data))
 
 
 def send_application_submission_completed(ses: SESClient, application: Application):
@@ -277,9 +273,7 @@ def send_mail_to_new_user(ses: SESClient, name: str, username: str, temp_passwor
     :param username: The username (email address) of the new user.
     :param temp_password: The temporary password for the new user.
     """
-
     images_base_url = get_images_base_url()
-
     html_data = {
         "USER": name,
         "SET_PASSWORD_IMAGE_LINK": f"{images_base_url}/set_password.png",
@@ -304,9 +298,7 @@ def send_upload_contract_notification_to_FI(ses: SESClient, application: Applica
     :param ses: SES client instance used to send emails.
     :param application: The application associated with the contract.
     """
-
     images_base_url = get_images_base_url()
-
     html_data = {
         "LOGIN_URL": app_settings.frontend_url + "/login",
         "LOGIN_IMAGE_LINK": images_base_url + "/logincompleteimage.png",
@@ -330,7 +322,6 @@ def send_upload_contract_confirmation(ses: SESClient, application: Application):
     :param ses: SES client instance used to send emails.
     :param application: The application associated with the contract.
     """
-
     html_data = {
         "AWARD_SUPPLIER_NAME": application.borrower.legal_name,
         "TENDER_TITLE": application.award.title,
@@ -367,7 +358,6 @@ def send_new_email_confirmation(
     :param application_uuid: The unique identifier for the application.
     :return: The ID of the sent message.
     """
-
     images_base_url = get_images_base_url()
     confirm_email_change_url = (
         app_settings.frontend_url
@@ -405,9 +395,7 @@ def send_mail_to_reset_password(ses: SESClient, username: str, temp_password: st
     :param username: The username associated with the account for which the password is to be reset.
     :param temp_password: A temporary password generated for the account.
     """
-
     images_base_url = get_images_base_url()
-
     html_data = {
         "USER_ACCOUNT": username,
         "RESET_PASSWORD_URL": app_settings.frontend_url
@@ -438,9 +426,7 @@ def send_invitation_email(
     :param tender_title: The title of the tender.
     :return: The MessageId of the sent email.
     """
-
     images_base_url = get_images_base_url()
-
     html_data = {
         "AWARD_SUPPLIER_NAME": borrower_name,
         "TENDER_TITLE": tender_title,
@@ -471,9 +457,7 @@ def send_mail_intro_reminder(
     :param tender_title: The title of the tender.
     :return: The MessageId of the sent email.
     """
-
     images_base_url = get_images_base_url()
-
     html_data = {
         "AWARD_SUPPLIER_NAME": borrower_name,
         "TENDER_TITLE": tender_title,
@@ -526,7 +510,6 @@ def send_notification_new_app_to_fi(ses: SESClient, lender_email_group: str):
     :param lender_email_group: List of email addresses belonging to the lender.
     """
     images_base_url = get_images_base_url()
-
     html_data = {
         "LOGIN_URL": app_settings.frontend_url + "/login",
         "LOGIN_IMAGE_LINK": images_base_url + "/logincompleteimage.png",
@@ -548,9 +531,7 @@ def send_notification_new_app_to_ocp(ses: SESClient, ocp_email_group: str, lende
     :param ocp_email_group: List of email addresses belonging to the OCP.
     :param lender_name: Name of the lender associated with the new application.
     """
-
     images_base_url = get_images_base_url()
-
     html_data = {
         "FI": lender_name,
         "LOGIN_URL": app_settings.frontend_url + "/login",
@@ -577,7 +558,6 @@ def send_mail_request_to_sme(ses: SESClient, uuid: str, lender_name: str, email_
     :return: The unique identifier for the sent message.
     """
     images_base_url = get_images_base_url()
-
     html_data = {
         "FI": lender_name,
         "FI_MESSAGE": email_message,
@@ -598,9 +578,7 @@ def send_overdue_application_email_to_FI(ses: SESClient, name: str, email: str, 
     :param amount: Number of overdue applications.
     :return: The unique identifier for the sent message.
     """
-
     images_base_url = get_images_base_url()
-
     html_data = {
         "USER": name,
         "NUMBER_APPLICATIONS": amount,
@@ -620,7 +598,6 @@ def send_overdue_application_email_to_OCP(ses: SESClient, name: str) -> str:
     :return: The unique identifier for the sent message.
     """
     images_base_url = get_images_base_url()
-
     html_data = {
         "USER": name,
         "FI": name,
@@ -645,7 +622,6 @@ def send_rejected_application_email(ses: SESClient, application: Application) ->
     :return: The unique identifier for the sent message.
     """
     images_base_url = get_images_base_url()
-
     html_data = {
         "FI": application.lender.name,
         "AWARD_SUPPLIER_NAME": application.borrower.legal_name,
@@ -665,7 +641,6 @@ def send_rejected_application_email_without_alternatives(ses: SESClient, applica
     :param application: An object that contains information about the application that was rejected.
     :return: The unique identifier for the sent message.
     """
-
     html_data = {
         "FI": application.lender.name,
         "AWARD_SUPPLIER_NAME": application.borrower.legal_name,
@@ -709,7 +684,6 @@ def send_upload_documents_notifications_to_FI(ses: SESClient, email: str) -> str
     :param email: Email address of the Financial Institution to receive the notification.
     :return: The unique identifier for the sent message.
     """
-
     images_base_url = get_images_base_url()
     html_data = {
         **generate_common_data(),

--- a/app/mail.py
+++ b/app/mail.py
@@ -194,7 +194,7 @@ def send_email(ses: SESClient, email: str, data: dict, to_msme: bool = True) -> 
         TemplateData=json.dumps(data),
     )
 
-    return response.get("MessageId")
+    return response["MessageId"]
 
 
 def send_application_approved_email(ses: SESClient, application: Application):
@@ -518,7 +518,7 @@ def send_mail_submit_reminder(
     return send_email(ses, email, prepare_html("Access_to_credit_reminder", html_data))
 
 
-def send_notification_new_app_to_fi(ses: SESClient, lender_email_group: list[str]):
+def send_notification_new_app_to_fi(ses: SESClient, lender_email_group: str):
     """
     Sends a notification email about a new application to a financial institution's email group.
 
@@ -540,7 +540,7 @@ def send_notification_new_app_to_fi(ses: SESClient, lender_email_group: list[str
     )
 
 
-def send_notification_new_app_to_ocp(ses: SESClient, ocp_email_group: list[str], lender_name: str):
+def send_notification_new_app_to_ocp(ses: SESClient, ocp_email_group: str, lender_name: str):
     """
     Sends a notification email about a new application to the Open Contracting Partnership's (OCP) email group.
 

--- a/app/models.py
+++ b/app/models.py
@@ -37,6 +37,7 @@ def _get_missing_data_keys(input_dict: dict) -> dict:
 
 # https://github.com/tiangolo/sqlmodel/issues/254
 class ActiveRecordMixin:
+    # https://github.com/tiangolo/sqlmodel/issues/348
     __config__ = None
 
     @classmethod
@@ -689,6 +690,7 @@ class Award(AwardBase, ActiveRecordMixin, table=True):
         obj = session.query(cls).order_by(desc(cls.source_last_updated_at)).first()
         if obj:
             return obj.source_last_updated_at
+        return None
 
 
 class Message(SQLModel, ActiveRecordMixin, table=True):

--- a/app/models.py
+++ b/app/models.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta
 from decimal import Decimal
 from enum import Enum
-from typing import Any, Optional
+from typing import Any, Optional, Self
 
 from pydantic import BaseModel
 from sqlalchemy import DECIMAL, Column, DateTime
@@ -53,7 +53,7 @@ class ActiveRecordMixin:
         return session.query(cls).filter(getattr(cls, field) == value)
 
     @classmethod
-    def first_by(cls, session: Session, field: str, value: Any):
+    def first_by(cls, session: Session, field: str, value: Any) -> Self | None:
         """
         Get an existing instance based on a field's value.
 
@@ -65,7 +65,7 @@ class ActiveRecordMixin:
         return cls.filter_by(session, field, value).first()
 
     @classmethod
-    def create(cls, session: Session, **data):
+    def create(cls, session: Session, **data) -> Self:
         """
         Insert a new instance into the database.
 
@@ -81,7 +81,7 @@ class ActiveRecordMixin:
         session.flush()
         return obj
 
-    def update(self, session: Session, **data):
+    def update(self, session: Session, **data) -> Self:
         """
         Update an existing instance in the database.
 

--- a/app/models.py
+++ b/app/models.py
@@ -375,8 +375,8 @@ class Application(ApplicationPrivate, ActiveRecordMixin, table=True):
     @classmethod
     def expiring_soon(cls, session: Session):
         return session.query(cls).filter(
-            cls.expired_at > datetime.now(),
-            cls.expired_at <= datetime.now() + timedelta(days=app_settings.reminder_days_before_expiration),
+            col(cls.expired_at) > datetime.now(),
+            col(cls.expired_at) <= datetime.now() + timedelta(days=app_settings.reminder_days_before_expiration),
         )
 
     @classmethod
@@ -407,15 +407,15 @@ class Application(ApplicationPrivate, ActiveRecordMixin, table=True):
             or_(
                 and_(
                     cls.status == ApplicationStatus.PENDING,
-                    cls.created_at + delta < datetime.now(),
+                    col(cls.created_at) + delta < datetime.now(),
                 ),
                 and_(
                     cls.status == ApplicationStatus.ACCEPTED,
-                    cls.borrower_accepted_at + delta < datetime.now(),
+                    col(cls.borrower_accepted_at) + delta < datetime.now(),
                 ),
                 and_(
                     cls.status == ApplicationStatus.INFORMATION_REQUESTED,
-                    cls.information_requested_at + delta < datetime.now(),
+                    col(cls.information_requested_at) + delta < datetime.now(),
                 ),
             ),
         )
@@ -448,19 +448,19 @@ class Application(ApplicationPrivate, ActiveRecordMixin, table=True):
             or_(
                 and_(
                     cls.status == ApplicationStatus.DECLINED,
-                    cls.borrower_declined_at + delta < datetime.now(),
+                    col(cls.borrower_declined_at) + delta < datetime.now(),
                 ),
                 and_(
                     cls.status == ApplicationStatus.REJECTED,
-                    cls.lender_rejected_at + delta < datetime.now(),
+                    col(cls.lender_rejected_at) + delta < datetime.now(),
                 ),
                 and_(
                     cls.status == ApplicationStatus.COMPLETED,
-                    cls.lender_approved_at + delta < datetime.now(),
+                    col(cls.lender_approved_at) + delta < datetime.now(),
                 ),
                 and_(
                     cls.status == ApplicationStatus.LAPSED,
-                    cls.application_lapsed_at + delta < datetime.now(),
+                    col(cls.application_lapsed_at) + delta < datetime.now(),
                 ),
             ),
         )

--- a/app/routers/applications.py
+++ b/app/routers/applications.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, U
 from fastapi.encoders import jsonable_encoder
 from sqlalchemy import asc, desc, text
 from sqlalchemy.orm import Session, joinedload
+from sqlmodel import col
 
 from app import dependencies, models, parsers, serializers, util
 from app.aws import CognitoClient
@@ -70,8 +71,8 @@ async def reject_application(
             .filter(
                 models.CreditProduct.borrower_size == application.borrower.size,
                 models.CreditProduct.lender_id != application.lender_id,
-                models.CreditProduct.lower_limit <= application.amount_requested,
-                models.CreditProduct.upper_limit >= application.amount_requested,
+                col(models.CreditProduct.lower_limit) <= application.amount_requested,
+                col(models.CreditProduct.upper_limit) >= application.amount_requested,
             )
             .all()
         )

--- a/app/routers/statistics.py
+++ b/app/routers/statistics.py
@@ -75,7 +75,7 @@ async def get_ocp_statistics_by_lender(
 
             statistics_kpis = statistics_utils.get_general_statistics(session, initial_date, final_date, lender_id)
 
-    except ClientError() as e:
+    except ClientError as e:
         logger.exception(e)
 
     return serializers.StatisticResponse(

--- a/app/sources/__init__.py
+++ b/app/sources/__init__.py
@@ -21,7 +21,7 @@ def is_valid_email(email: str) -> bool:
     return False
 
 
-def make_request_with_retry(url: str, headers: dict) -> httpx.Response | None:
+def make_request_with_retry(url: str, headers: dict) -> httpx.Response:
     """
     Make an HTTP request with retry functionality.
 
@@ -37,8 +37,5 @@ def make_request_with_retry(url: str, headers: dict) -> httpx.Response | None:
         response = client.get(url)
         response.raise_for_status()
         return response
-    except (httpx.TimeoutException, httpx.HTTPStatusError) as error:
-        logger.exception(f"Request failed: {error}")
-        return None
     finally:
         client.close()

--- a/app/sources/colombia.py
+++ b/app/sources/colombia.py
@@ -107,7 +107,7 @@ def create_new_award(
     return new_award
 
 
-def get_new_contracts(index: int, from_date, until_date=None):
+def get_new_contracts(index: int, from_date: datetime, until_date: datetime | None = None) -> httpx.Response:
     offset = index * app_settings.secop_pagination_limit
     delta = timedelta(days=app_settings.secop_default_days_from_ultima_actualizacion)
     date_format = "%Y-%m-%dT%H:%M:%S.000"
@@ -131,7 +131,7 @@ def get_new_contracts(index: int, from_date, until_date=None):
     return sources.make_request_with_retry(url, headers)
 
 
-def get_previous_contracts(documento_proveedor: str) -> httpx.Response | None:
+def get_previous_contracts(documento_proveedor: str) -> httpx.Response:
     """
     Get previous contracts data for the given document provider from the source API.
 

--- a/app/util.py
+++ b/app/util.py
@@ -52,13 +52,12 @@ def get_secret_hash(nit_entidad: str) -> str:
     :return: The secret hash generated from the NIT.
     """
 
-    key = app_settings.hash_key
     message = bytes(nit_entidad, "utf-8")
-    key = bytes(key, "utf-8")
+    key = bytes(app_settings.hash_key, "utf-8")
     return base64.b64encode(hmac.new(key, message, digestmod=hashlib.sha256).digest()).decode()
 
 
-def validate_file(file: UploadFile = File(...)) -> dict[File, str]:
+def validate_file(file: UploadFile = File(...)) -> tuple[bytes, str | None]:
     """
     Validates the uploaded file.
 

--- a/app/utils/background.py
+++ b/app/utils/background.py
@@ -1,6 +1,7 @@
 import logging
 from contextlib import contextmanager
 from datetime import datetime, timedelta
+from typing import Callable, Generator
 
 from sqlalchemy.orm import Session
 
@@ -92,7 +93,11 @@ def _create_award(
     return models.Award.create(session, **data)
 
 
-def fetch_new_awards_from_date(last_updated_award_date: str, db_provider: Session, until_date: str | None = None):
+def fetch_new_awards_from_date(
+    last_updated_award_date: str,
+    db_provider: Callable[[], Generator[Session, None, None]],
+    until_date: str | None = None,
+):
     """
     Fetch new awards from the given date and process them.
 
@@ -146,7 +151,9 @@ def fetch_new_awards_from_date(last_updated_award_date: str, db_provider: Sessio
     logger.info("Total fetched contracts: %d", total)
 
 
-def fetch_previous_awards(borrower: models.Borrower, db_provider: Session = get_db):
+def fetch_previous_awards(
+    borrower: models.Borrower, db_provider: Callable[[], Generator[Session, None, None]] = get_db
+):
     """
     Fetch previous awards for a borrower that accepted an application. This wont generate an application,
     it will just insert the awards in our database

--- a/app/utils/background.py
+++ b/app/utils/background.py
@@ -94,9 +94,9 @@ def _create_award(
 
 
 def fetch_new_awards_from_date(
-    last_updated_award_date: str,
+    last_updated_award_date: datetime,
     db_provider: Callable[[], Generator[Session, None, None]],
-    until_date: str | None = None,
+    until_date: datetime | None = None,
 ):
     """
     Fetch new awards from the given date and process them.

--- a/app/utils/statistics.py
+++ b/app/utils/statistics.py
@@ -159,13 +159,13 @@ def _get_base_query(
     base_query = None
     if start_date is not None and end_date is not None:
         base_query = sessionBase.filter(
-            Application.created_at >= start_date,
-            Application.created_at <= end_date,
+            col(Application.created_at) >= start_date,
+            col(Application.created_at) <= end_date,
         )
     elif start_date is not None:
-        base_query = sessionBase.filter(Application.created_at >= start_date)
+        base_query = sessionBase.filter(col(Application.created_at) >= start_date)
     elif end_date is not None:
-        base_query = sessionBase.filter(Application.created_at <= end_date)
+        base_query = sessionBase.filter(col(Application.created_at) <= end_date)
     else:
         base_query = sessionBase
 
@@ -252,7 +252,9 @@ def get_general_statistics(
     # Average Repayment Period
     average_repayment_period_query = (
         _get_base_query(
-            session.query(func.avg(Application.repayment_years * 12 + Application.repayment_months).cast(Integer)),
+            session.query(
+                func.avg(col(Application.repayment_years) * 12 + col(Application.repayment_months)).cast(Integer)
+            ),
             start_date,
             end_date,
             lender_id,

--- a/app/utils/statistics.py
+++ b/app/utils/statistics.py
@@ -1,6 +1,7 @@
 import logging
 from contextlib import contextmanager
 from datetime import datetime
+from typing import Callable, Generator
 
 from sqlalchemy import Date, Integer, cast, distinct, func, text
 from sqlalchemy.orm import Session
@@ -23,7 +24,7 @@ from app.models import (
 logger = logging.getLogger(__name__)
 
 
-def update_statistics(db_provider: Session = get_db):
+def update_statistics(db_provider: Callable[[], Generator[Session, None, None]] = get_db):
     """
     Update and store various statistics related to applications and lenders in the database.
 
@@ -298,7 +299,7 @@ def get_general_statistics(
 
     # Calculate the proportion
     if application_accepted_query == 0:
-        proportion_of_submitted_out_of_opt_in = 0
+        proportion_of_submitted_out_of_opt_in = 0.0
     else:
         proportion_of_submitted_out_of_opt_in = round((application_accepted_query / application_divisor) * 100, 2)
 


### PR DESCRIPTION
- docs: Switch module from Google-style to RST-style docstrings
- chore(typing): Use col() for arithmetic and comparisons
- feat: Guarantee that SessionLocal is not None
- chore(typing): Add type hints to db module. Correct type hints for db_provider. Fix simple mypy errors.
- chore: Normalize whitespace in mail module
- chore(typing): Remove unused, shadowed Response argument. Fix except clause. Avoid shadowed variables. Fix incorrect type hints. Add missing type hints. Remove inline type hint.
- fix: Raise 404 error if no user returned by get_user() dependency (restore "User not found" message from b470cd7)
- fix: Raise error if make_request_with_retry errors (instead of logging exception and then causing programming error), closes #211
- fix: Fix type hints for fetch_new_awards_from_date to match implementation, #212
