### PR TITLE
chore: Prepare for upgrades of fastapi, sqlmodel, pydantic

### DIFF
--- a/app/commands.py
+++ b/app/commands.py
@@ -76,7 +76,7 @@ def remove_dated_application_data() -> None:
                 for document in application.borrower_documents:
                     session.delete(document)
 
-                # Check if there are any other active borrowers with active applications
+                # Check if the borrower has other active applications
                 active_applications_with_same_borrower = (
                     models.Application.unarchived(session)
                     .filter(

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -150,7 +150,7 @@ def _get_application_as_guest_via_uuid(session: Session, uuid: str) -> models.Ap
     if application.status == models.ApplicationStatus.LAPSED:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
-            detail=util.ERROR_CODES.APPLICATION_LAPSED.value,
+            detail=util.ERROR_CODES.APPLICATION_LAPSED,
         )
 
     return application

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -97,7 +97,7 @@ def raise_if_unauthorized(
         if application.status not in statuses:
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
-                detail=f"Application status should not be {application.status.name}",
+                detail=f"Application status should not be {application.status}",
             )
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -274,13 +274,7 @@ class BorrowerDocumentBase(SQLModel):
         sa_column=Column(DateTime(timezone=True), nullable=False, default=datetime.utcnow(), server_default=func.now())
     )
     updated_at: datetime | None = Field(
-        sa_column=Column(
-            DateTime(timezone=True),
-            nullable=False,
-            default=datetime.utcnow(),
-            onupdate=func.now(),
-            server_default=func.now(),
-        )
+        sa_column=Column(DateTime(timezone=True), nullable=False, default=datetime.utcnow(), onupdate=func.now())
     )
     submitted_at: datetime | None = Field(
         sa_column=Column(DateTime(timezone=True), nullable=False, default=datetime.utcnow(), server_default=func.now())

--- a/app/models.py
+++ b/app/models.py
@@ -256,20 +256,10 @@ class CreditProduct(CreditProductBase, ActiveRecordMixin, table=True):
     id: int | None = Field(default=None, primary_key=True)
     lender: "Lender" = Relationship(back_populates="credit_products")
     created_at: datetime | None = Field(
-        sa_column=Column(
-            DateTime(timezone=True),
-            nullable=False,
-            default=datetime.utcnow(),
-            server_default=func.now(),
-        )
+        sa_column=Column(DateTime(timezone=True), nullable=False, default=datetime.utcnow(), server_default=func.now())
     )
     updated_at: datetime | None = Field(
-        sa_column=Column(
-            DateTime(timezone=True),
-            nullable=False,
-            default=datetime.utcnow(),
-            onupdate=func.now(),
-        )
+        sa_column=Column(DateTime(timezone=True), nullable=False, default=datetime.utcnow(), onupdate=func.now())
     )
 
 
@@ -281,12 +271,7 @@ class BorrowerDocumentBase(SQLModel):
     verified: bool = Field(default=False)
     name: str = Field(default="")
     created_at: datetime | None = Field(
-        sa_column=Column(
-            DateTime(timezone=True),
-            nullable=False,
-            default=datetime.utcnow(),
-            server_default=func.now(),
-        )
+        sa_column=Column(DateTime(timezone=True), nullable=False, default=datetime.utcnow(), server_default=func.now())
     )
     updated_at: datetime | None = Field(
         sa_column=Column(
@@ -298,12 +283,7 @@ class BorrowerDocumentBase(SQLModel):
         )
     )
     submitted_at: datetime | None = Field(
-        sa_column=Column(
-            DateTime(timezone=True),
-            nullable=False,
-            default=datetime.utcnow(),
-            server_default=func.now(),
-        )
+        sa_column=Column(DateTime(timezone=True), nullable=False, default=datetime.utcnow(), server_default=func.now())
     )
 
 
@@ -354,20 +334,10 @@ class ApplicationBase(SQLModel):
     lender_completed_at: datetime | None = Field(sa_column=Column(DateTime(timezone=True), nullable=True))
     completed_in_days: int | None = Field(nullable=True)
     created_at: datetime | None = Field(
-        sa_column=Column(
-            DateTime(timezone=True),
-            nullable=False,
-            default=datetime.utcnow(),
-            server_default=func.now(),
-        )
+        sa_column=Column(DateTime(timezone=True), nullable=False, default=datetime.utcnow(), server_default=func.now())
     )
     updated_at: datetime | None = Field(
-        sa_column=Column(
-            DateTime(timezone=True),
-            nullable=False,
-            default=datetime.utcnow(),
-            onupdate=func.now(),
-        )
+        sa_column=Column(DateTime(timezone=True), nullable=False, default=datetime.utcnow(), onupdate=func.now())
     )
     expired_at: datetime | None = Field(sa_column=Column(DateTime(timezone=True), nullable=True))
     archived_at: datetime | None = Field(sa_column=Column(DateTime(timezone=True), nullable=True))
@@ -595,20 +565,10 @@ class BorrowerBase(SQLModel):
     )
     missing_data: dict[str, bool] = Field(default={}, sa_column=Column(JSON), nullable=False)
     created_at: datetime | None = Field(
-        sa_column=Column(
-            DateTime(timezone=True),
-            nullable=False,
-            default=datetime.utcnow(),
-            server_default=func.now(),
-        )
+        sa_column=Column(DateTime(timezone=True), nullable=False, default=datetime.utcnow(), server_default=func.now())
     )
     updated_at: datetime | None = Field(
-        sa_column=Column(
-            DateTime(timezone=True),
-            nullable=False,
-            default=datetime.utcnow(),
-            onupdate=func.now(),
-        )
+        sa_column=Column(DateTime(timezone=True), nullable=False, default=datetime.utcnow(), onupdate=func.now())
     )
     declined_at: datetime | None = Field(sa_column=Column(DateTime(timezone=True), nullable=True))
 
@@ -637,20 +597,10 @@ class Lender(LenderBase, ActiveRecordMixin, table=True):
     users: list["User"] | None = Relationship(back_populates="lender")
     status: str = Field(default="")
     created_at: datetime | None = Field(
-        sa_column=Column(
-            DateTime(timezone=True),
-            nullable=False,
-            default=datetime.utcnow(),
-            server_default=func.now(),
-        )
+        sa_column=Column(DateTime(timezone=True), nullable=False, default=datetime.utcnow(), server_default=func.now())
     )
     updated_at: datetime | None = Field(
-        sa_column=Column(
-            DateTime(timezone=True),
-            nullable=False,
-            default=datetime.utcnow(),
-            onupdate=func.now(),
-        )
+        sa_column=Column(DateTime(timezone=True), nullable=False, default=datetime.utcnow(), onupdate=func.now())
     )
     deleted_at: datetime | None = Field(sa_column=Column(DateTime(timezone=True), nullable=True))
     credit_products: list["CreditProduct"] | None = Relationship(back_populates="lender")
@@ -690,20 +640,10 @@ class Award(AwardBase, ActiveRecordMixin, table=True):
     source_data_contracts: dict[str, Any] = Field(default={}, sa_column=Column(JSON), nullable=False)
     source_data_awards: dict[str, Any] = Field(default={}, sa_column=Column(JSON), nullable=False)
     created_at: datetime | None = Field(
-        sa_column=Column(
-            DateTime(timezone=True),
-            nullable=False,
-            default=datetime.utcnow(),
-            server_default=func.now(),
-        )
+        sa_column=Column(DateTime(timezone=True), nullable=False, default=datetime.utcnow(), server_default=func.now())
     )
     updated_at: datetime | None = Field(
-        sa_column=Column(
-            DateTime(timezone=True),
-            nullable=False,
-            default=datetime.utcnow(),
-            onupdate=func.now(),
-        )
+        sa_column=Column(DateTime(timezone=True), nullable=False, default=datetime.utcnow(), onupdate=func.now())
     )
 
     @classmethod
@@ -727,20 +667,10 @@ class Message(SQLModel, ActiveRecordMixin, table=True):
     external_message_id: str | None = Field(default="")
     body: str | None = Field(default="")
     created_at: datetime | None = Field(
-        sa_column=Column(
-            DateTime(timezone=True),
-            nullable=False,
-            default=datetime.utcnow(),
-            server_default=func.now(),
-        )
+        sa_column=Column(DateTime(timezone=True), nullable=False, default=datetime.utcnow(), server_default=func.now())
     )
     updated_at: datetime | None = Field(
-        sa_column=Column(
-            DateTime(timezone=True),
-            nullable=False,
-            default=datetime.utcnow(),
-            onupdate=func.now(),
-        )
+        sa_column=Column(DateTime(timezone=True), nullable=False, default=datetime.utcnow(), onupdate=func.now())
     )
     lender_id: int | None = Field(default=None, foreign_key="lender.id", nullable=True)
 
@@ -761,12 +691,7 @@ class UserBase(SQLModel):
     external_id: str = Field(default="", index=True)
     lender_id: int | None = Field(default=None, foreign_key="lender.id", nullable=True)
     created_at: datetime | None = Field(
-        sa_column=Column(
-            DateTime(timezone=True),
-            nullable=False,
-            default=datetime.utcnow(),
-            server_default=func.now(),
-        )
+        sa_column=Column(DateTime(timezone=True), nullable=False, default=datetime.utcnow(), server_default=func.now())
     )
 
     def is_OCP(self) -> bool:
@@ -794,12 +719,7 @@ class ApplicationAction(SQLModel, ActiveRecordMixin, table=True):
     user_id: int = Field(default=None, foreign_key="credere_user.id")
     user: User | None = Relationship(back_populates="application_actions")
     created_at: datetime | None = Field(
-        sa_column=Column(
-            DateTime(timezone=True),
-            nullable=False,
-            default=datetime.utcnow(),
-            server_default=func.now(),
-        )
+        sa_column=Column(DateTime(timezone=True), nullable=False, default=datetime.utcnow(), server_default=func.now())
     )
 
     class Config:
@@ -853,11 +773,5 @@ class Statistic(SQLModel, table=True):
     id: int | None = Field(default=None, primary_key=True)
     type: StatisticType = Field(sa_column=Column(Enum(StatisticType, name="statistic_type")))
     data: dict[str, Any] = Field(default={}, sa_column=Column(JSON))
-    created_at: datetime | None = Field(
-        sa_column=Column(
-            DateTime(timezone=True),
-            nullable=False,
-            onupdate=func.now(),
-        )
-    )
+    created_at: datetime | None = Field(sa_column=Column(DateTime(timezone=True), nullable=False, onupdate=func.now()))
     lender_id: int | None = Field(foreign_key="lender.id", nullable=True)

--- a/app/routers/applications.py
+++ b/app/routers/applications.py
@@ -177,7 +177,7 @@ async def approve_application(
         not_validated_documents = []
         for document in application.borrower_documents:
             if not document.verified:
-                not_validated_documents.append(document.type.name)
+                not_validated_documents.append(document.type)
         if not_validated_documents:
             logger.error("Following documents were not validated: %s", not_validated_documents)
             raise HTTPException(

--- a/app/routers/applications.py
+++ b/app/routers/applications.py
@@ -170,7 +170,7 @@ async def approve_application(
             logger.error("Following fields were not validated: %s", not_validated_fields)
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
-                detail=util.ERROR_CODES.BORROWER_FIELD_VERIFICATION_MISSING.value,
+                detail=util.ERROR_CODES.BORROWER_FIELD_VERIFICATION_MISSING,
             )
 
         # Check all documents are verified.
@@ -182,7 +182,7 @@ async def approve_application(
             logger.error("Following documents were not validated: %s", not_validated_documents)
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
-                detail=util.ERROR_CODES.DOCUMENT_VERIFICATION_MISSING.value,
+                detail=util.ERROR_CODES.DOCUMENT_VERIFICATION_MISSING,
             )
 
         # Approve the application.

--- a/app/routers/downloads.py
+++ b/app/routers/downloads.py
@@ -167,9 +167,7 @@ async def export_applications(
                 get_translated_string("Legal Name", lang): application.borrower.legal_name,
                 get_translated_string("Email Address", lang): application.primary_email,
                 get_translated_string("Submission Date", lang): application.borrower_submitted_at,
-                get_translated_string("Stage", lang): get_translated_string(
-                    application.status.name.capitalize(), lang
-                ),
+                get_translated_string("Stage", lang): get_translated_string(application.status.capitalize(), lang),
             }
         )
 

--- a/app/routers/guest/applications.py
+++ b/app/routers/guest/applications.py
@@ -228,9 +228,9 @@ async def credit_product_options(
 
         filter = None
         if application.borrower.type.lower() == "persona natural colombiana":
-            filter = text(f"(borrower_types->>'{models.BorrowerType.NATURAL_PERSON.value}')::boolean is True")
+            filter = text(f"(borrower_types->>'{models.BorrowerType.NATURAL_PERSON}')::boolean is True")
         else:
-            filter = text(f"(borrower_types->>'{models.BorrowerType.LEGAL_PERSON.value}')::boolean is True")
+            filter = text(f"(borrower_types->>'{models.BorrowerType.LEGAL_PERSON}')::boolean is True")
 
         loans_query = (
             session.query(models.CreditProduct)
@@ -752,7 +752,7 @@ async def find_alternative_credit_option(
         if app_action:
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
-                detail=util.ERROR_CODES.APPLICATION_ALREADY_COPIED.value,
+                detail=util.ERROR_CODES.APPLICATION_ALREADY_COPIED,
             )
 
         # Copy the application, changing the uuid, status, and borrower_accepted_at.

--- a/app/routers/statistics.py
+++ b/app/routers/statistics.py
@@ -63,9 +63,9 @@ async def get_ocp_statistics_by_lender(
         if custom_range is not None:
             custom_range = custom_range.upper()
             current_date = datetime.now().date()
-            if custom_range == StatisticCustomRange.LAST_WEEK.value:
+            if custom_range == StatisticCustomRange.LAST_WEEK:
                 initial_date = (current_date - timedelta(days=7)).isoformat()
-            elif custom_range == StatisticCustomRange.LAST_MONTH.value:
+            elif custom_range == StatisticCustomRange.LAST_MONTH:
                 initial_date = (current_date - timedelta(days=30)).isoformat()
 
             final_date = current_date.isoformat()

--- a/app/sources/__init__.py
+++ b/app/sources/__init__.py
@@ -15,9 +15,7 @@ def is_valid_email(email: str) -> bool:
     :param email: The email address to validate.
     :return: True if the email is valid, False otherwise.
     """
-    if email and re.search(VALID_EMAIL, email):
-        return True
-    return False
+    return bool(re.search(VALID_EMAIL, email))
 
 
 def make_request_with_retry(url: str, headers: dict[str, str]) -> httpx.Response:

--- a/app/sources/colombia.py
+++ b/app/sources/colombia.py
@@ -26,7 +26,7 @@ def _get_remote_award(proceso_de_compra: str, proveedor_adjudicado: str) -> tupl
     return sources.make_request_with_retry(award_url, HEADERS).json(), award_url
 
 
-def create_new_award(
+def get_award(
     source_contract_id: str,
     entry: dict[str, Any],
     borrower_id: int | None = None,

--- a/app/util.py
+++ b/app/util.py
@@ -4,7 +4,7 @@ import hmac
 import os.path
 import uuid
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 
 from fastapi import File, HTTPException, UploadFile, status
@@ -18,7 +18,7 @@ MAX_FILE_SIZE = app_settings.max_file_size_mb * 1024 * 1024  # MB in bytes
 ALLOWED_EXTENSIONS = {".png", ".pdf", ".jpeg", ".jpg"}
 
 
-class ERROR_CODES(Enum):
+class ERROR_CODES(StrEnum):
     BORROWER_FIELD_VERIFICATION_MISSING = "BORROWER_FIELD_VERIFICATION_MISSING"
     DOCUMENT_VERIFICATION_MISSING = "DOCUMENT_VERIFICATION_MISSING"
     APPLICATION_LAPSED = "APPLICATION_LAPSED"
@@ -91,7 +91,7 @@ def get_modified_data_fields(application: models.Application, session: Session) 
         .filter(
             models.ApplicationAction.application_id == application.id,
             col(models.ApplicationAction.type).in_(
-                [models.ApplicationActionType.AWARD_UPDATE.value, models.ApplicationActionType.BORROWER_UPDATE.value]
+                [models.ApplicationActionType.AWARD_UPDATE, models.ApplicationActionType.BORROWER_UPDATE]
             ),
         )
         .all()

--- a/app/utils/background.py
+++ b/app/utils/background.py
@@ -93,7 +93,7 @@ def _create_award(
     if models.Award.first_by(session, "source_contract_id", source_contract_id):
         raise SkippedAwardError(f"[{previous=}] Award already exists with {source_contract_id=} ({entry=})")
 
-    data = data_access.create_new_award(source_contract_id, entry, borrower_id, previous)
+    data = data_access.get_award(source_contract_id, entry, borrower_id, previous)
 
     return models.Award.create(session, **data)
 

--- a/tests/common/utils.py
+++ b/tests/common/utils.py
@@ -5,20 +5,20 @@ from app import models
 FI_user = {
     "email": "FI_user@noreply.open-contracting.org",
     "name": "Test FI",
-    "type": models.UserType.FI.value,
+    "type": models.UserType.FI,
 }
 
 FI_user_with_lender = {
     "email": "FI_user_with_lender@noreply.open-contracting.org",
     "name": "Test FI with lender",
-    "type": models.UserType.FI.value,
+    "type": models.UserType.FI,
     "lender_id": 1,
 }
 
 OCP_user = {
     "email": "OCP_user@noreply.open-contracting.org",
     "name": "OCP_user@example.com",
-    "type": models.UserType.OCP.value,
+    "type": models.UserType.OCP,
 }
 
 application_status_values = tuple(key.value for key in models.ApplicationStatus)

--- a/tests/protected_routes/applications_test.py
+++ b/tests/protected_routes/applications_test.py
@@ -74,7 +74,7 @@ async def set_test_application_as_started(id: int, session: Session = Depends(ge
     application = session.query(models.Application).filter(models.Application.id == id).first()
 
     application.lender_started_at = datetime.now(application.created_at.tzinfo)
-    application.status = models.ApplicationStatus.STARTED.value
+    application.status = models.ApplicationStatus.STARTED
 
     session.commit()
     session.refresh(application)
@@ -90,7 +90,7 @@ async def set_test_application_as_started(id: int, session: Session = Depends(ge
 async def set_test_application_as_overdue(id: int, session: Session = Depends(get_db)):
     application = session.query(models.Application).filter(models.Application.id == id).first()
 
-    application.status = models.ApplicationStatus.STARTED.value
+    application.status = models.ApplicationStatus.STARTED
     application.lender_started_at = datetime.now(application.created_at.tzinfo) - timedelta(
         days=application.lender.sla_days + 1
     )
@@ -109,7 +109,7 @@ async def set_test_application_as_overdue(id: int, session: Session = Depends(ge
 async def set_test_application_as_expired(id: int, session: Session = Depends(get_db)):
     application = session.query(models.Application).filter(models.Application.id == id).first()
 
-    application.status = models.ApplicationStatus.PENDING.value
+    application.status = models.ApplicationStatus.PENDING
     application.expired_at = datetime.now(application.created_at.tzinfo) - timedelta(days=+1)
 
     session.commit()

--- a/tests/test_SLA_overdue_applications.py
+++ b/tests/test_SLA_overdue_applications.py
@@ -10,13 +10,13 @@ from tests.common.common_test_client import app, client  # isort:skip # noqa
 OCP_user = {
     "email": "OCP_user@example.com",
     "name": "OCP_user@example.com",
-    "type": models.UserType.OCP.value,
+    "type": models.UserType.OCP,
 }
 
-application = {"status": models.ApplicationStatus.STARTED.value}
+application = {"status": models.ApplicationStatus.STARTED}
 
 application_with_lender_payload = {
-    "status": models.ApplicationStatus.STARTED.value,
+    "status": models.ApplicationStatus.STARTED,
     "lender_id": 1,
 }
 lender = {

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -18,7 +18,7 @@ wrong_file = os.path.join(__location__, "file.gif")
 FI_user = {
     "email": "FI_user@noreply.open-contracting.org",
     "name": "Test FI",
-    "type": models.UserType.FI.value,
+    "type": models.UserType.FI,
 }
 
 
@@ -26,7 +26,7 @@ FI_user_with_lender = {
     "id": 2,
     "email": "FI_user_with_lender@noreply.open-contracting.org",
     "name": "Test FI with lender",
-    "type": models.UserType.FI.value,
+    "type": models.UserType.FI,
     "lender_id": 1,
 }
 
@@ -34,39 +34,39 @@ FI_user_with_lender_2 = {
     "id": 3,
     "email": "FI_user_with_lender_2@noreply.open-contracting.org",
     "name": "Test FI with lender 2",
-    "type": models.UserType.FI.value,
+    "type": models.UserType.FI,
     "lender_id": 2,
 }
 
 OCP_user = {
     "email": "OCP_user@noreply.open-contracting.org",
     "name": "OCP_user@noreply.open-contracting.org",
-    "type": models.UserType.OCP.value,
+    "type": models.UserType.OCP,
 }
 
 application_base = {"uuid": "123-456-789"}
-application_payload = {"status": models.ApplicationStatus.PENDING.value}
+application_payload = {"status": models.ApplicationStatus.PENDING}
 application_with_lender_payload = {
-    "status": models.ApplicationStatus.PENDING.value,
+    "status": models.ApplicationStatus.PENDING,
     "lender_id": 1,
     "credit_product_id": 1,
 }
 application_with_credit_product = {
-    "status": models.ApplicationStatus.ACCEPTED.value,
+    "status": models.ApplicationStatus.ACCEPTED,
     "credit_product_id": 1,
 }
-application_lapsed_payload = {"status": models.ApplicationStatus.LAPSED.value}
-application_declined_payload = {"status": models.ApplicationStatus.DECLINED.value}
-borrower_declined_oportunity_payload = {"status": models.BorrowerStatus.DECLINE_OPPORTUNITIES.value}
+application_lapsed_payload = {"status": models.ApplicationStatus.LAPSED}
+application_declined_payload = {"status": models.ApplicationStatus.DECLINED}
+borrower_declined_oportunity_payload = {"status": models.BorrowerStatus.DECLINE_OPPORTUNITIES}
 application_credit_option = {
     "uuid": "123-456-789",
-    "borrower_size": models.BorrowerSize.SMALL.value,
+    "borrower_size": models.BorrowerSize.SMALL,
     "amount_requested": 10000,
 }
 
 application_select_credit_option = {
     "uuid": "123-456-789",
-    "borrower_size": models.BorrowerSize.SMALL.value,
+    "borrower_size": models.BorrowerSize.SMALL,
     "amount_requested": 10000,
     "sector": "adminstration",
     "credit_product_id": 1,
@@ -140,7 +140,7 @@ def test_reject_application(client, mock_templated_email):  # noqa
 
     response = client.post(
         "/applications/1/update-test-application-status",
-        json={"status": models.ApplicationStatus.STARTED.value},
+        json={"status": models.ApplicationStatus.STARTED},
     )
 
     response = client.post(
@@ -148,7 +148,7 @@ def test_reject_application(client, mock_templated_email):  # noqa
         json=reject_payload,
         headers=FI_headers,
     )
-    assert response.json()["status"] == models.ApplicationStatus.REJECTED.value
+    assert response.json()["status"] == models.ApplicationStatus.REJECTED
     assert response.status_code == status.HTTP_200_OK
 
     response = client.post("/applications/find-alternative-credit-option", json=application_base)
@@ -196,7 +196,7 @@ def test_approve_application_cicle(client, mock_templated_email):  # noqa
         return_value=MockResponse(status.HTTP_200_OK, {}),
     ):
         response = client.post("/applications/access-scheme", json=application_base)
-        assert response.json()["application"]["status"] == models.ApplicationStatus.ACCEPTED.value
+        assert response.json()["application"]["status"] == models.ApplicationStatus.ACCEPTED
         assert response.status_code == status.HTTP_200_OK
 
         # Application should be accepted now so it cannot be accepted again
@@ -268,7 +268,7 @@ def test_approve_application_cicle(client, mock_templated_email):  # noqa
     assert response.status_code == status.HTTP_409_CONFLICT
 
     response = client.post("/applications/submit", json=application_base)
-    assert response.json()["application"]["status"] == models.ApplicationStatus.SUBMITTED.value
+    assert response.json()["application"]["status"] == models.ApplicationStatus.SUBMITTED
     assert response.status_code == status.HTTP_200_OK
 
     # tries to upload document before application starting
@@ -277,7 +277,7 @@ def test_approve_application_cicle(client, mock_templated_email):  # noqa
             "/applications/upload-document",
             data={
                 "uuid": "123-456-789",
-                "type": models.BorrowerDocumentType.INCORPORATION_DOCUMENT.value,
+                "type": models.BorrowerDocumentType.INCORPORATION_DOCUMENT,
             },
             files={"file": (file_to_upload.name, file_to_upload, "image/jpeg")},
         )
@@ -297,7 +297,7 @@ def test_approve_application_cicle(client, mock_templated_email):  # noqa
 
     # The FI user starts application
     response = client.post("/applications/1/start", headers=FI_headers)
-    assert response.json()["status"] == models.ApplicationStatus.STARTED.value
+    assert response.json()["status"] == models.ApplicationStatus.STARTED
     assert response.status_code == status.HTTP_200_OK
 
     # different FI user tries to update the award
@@ -357,7 +357,7 @@ def test_approve_application_cicle(client, mock_templated_email):  # noqa
         headers=FI_headers,
     )
 
-    assert response.json()["status"] == models.ApplicationStatus.INFORMATION_REQUESTED.value
+    assert response.json()["status"] == models.ApplicationStatus.INFORMATION_REQUESTED
     assert response.status_code == status.HTTP_200_OK
 
     # borrower uploads the wrong type of document
@@ -366,7 +366,7 @@ def test_approve_application_cicle(client, mock_templated_email):  # noqa
             "/applications/upload-document",
             data={
                 "uuid": "123-456-789",
-                "type": models.BorrowerDocumentType.INCORPORATION_DOCUMENT.value,
+                "type": models.BorrowerDocumentType.INCORPORATION_DOCUMENT,
             },
             files={"file": (file_to_upload.name, file_to_upload, "image/jpeg")},
         )
@@ -377,14 +377,14 @@ def test_approve_application_cicle(client, mock_templated_email):  # noqa
             "/applications/upload-document",
             data={
                 "uuid": "123-456-789",
-                "type": models.BorrowerDocumentType.INCORPORATION_DOCUMENT.value,
+                "type": models.BorrowerDocumentType.INCORPORATION_DOCUMENT,
             },
             files={"file": (file_to_upload.name, file_to_upload, "image/jpeg")},
         )
         assert response.status_code == status.HTTP_200_OK
 
         response = client.post("/applications/complete-information-request", json={"uuid": "123-456-789"})
-        assert response.json()["application"]["status"] == models.ApplicationStatus.STARTED.value
+        assert response.json()["application"]["status"] == models.ApplicationStatus.STARTED
         assert response.status_code == status.HTTP_200_OK
 
         response = client.get("/applications/documents/id/1", headers=FI_headers)
@@ -436,7 +436,7 @@ def test_approve_application_cicle(client, mock_templated_email):  # noqa
         json=approve_application,
         headers=FI_headers,
     )
-    assert response.json()["status"] == models.ApplicationStatus.APPROVED.value
+    assert response.json()["status"] == models.ApplicationStatus.APPROVED
     assert response.status_code == status.HTTP_200_OK
 
     # msme uploads contract
@@ -453,7 +453,7 @@ def test_approve_application_cicle(client, mock_templated_email):  # noqa
         json={"uuid": "123-456-789", "contract_amount_submitted": 100000},
     )
     assert response.status_code == status.HTTP_200_OK
-    assert response.json()["application"]["status"] == models.ApplicationStatus.CONTRACT_UPLOADED.value
+    assert response.json()["application"]["status"] == models.ApplicationStatus.CONTRACT_UPLOADED
 
     response = client.post(
         "/applications/1/complete-application",
@@ -461,7 +461,7 @@ def test_approve_application_cicle(client, mock_templated_email):  # noqa
         headers=FI_headers,
     )
     assert response.status_code == status.HTTP_200_OK
-    assert response.json()["status"] == models.ApplicationStatus.COMPLETED.value
+    assert response.json()["status"] == models.ApplicationStatus.COMPLETED
 
 
 def test_get_applications(client):  # noqa
@@ -521,8 +521,8 @@ def test_application_declined(client, mock_templated_email):  # noqa
         "/applications/decline",
         json={"uuid": "123-456-789", "decline_this": False, "decline_all": True},
     )
-    assert response.json()["application"]["status"] == models.ApplicationStatus.DECLINED.value
-    assert response.json()["borrower"]["status"] == models.BorrowerStatus.DECLINE_OPPORTUNITIES.value
+    assert response.json()["application"]["status"] == models.ApplicationStatus.DECLINED
+    assert response.json()["borrower"]["status"] == models.BorrowerStatus.DECLINE_OPPORTUNITIES
     assert response.status_code == status.HTTP_200_OK
 
     response = client.post("/applications/access-scheme", json={"uuid": "123-456-789"})
@@ -535,8 +535,8 @@ def test_application_rollback_declined(client):  # isort:skip # noqa
 
     response = client.post("/applications/rollback-decline", json={"uuid": "123-456-789"})
 
-    assert response.json()["application"]["status"] == models.ApplicationStatus.PENDING.value
-    assert response.json()["borrower"]["status"] == models.BorrowerStatus.ACTIVE.value
+    assert response.json()["application"]["status"] == models.ApplicationStatus.PENDING
+    assert response.json()["borrower"]["status"] == models.BorrowerStatus.ACTIVE
     assert response.status_code == status.HTTP_200_OK
 
     response = client.post("/applications/rollback-decline", json={"uuid": "123-456-789"})
@@ -546,7 +546,7 @@ def test_application_rollback_declined(client):  # isort:skip # noqa
 def test_application_declined_feedback(client):  # isort:skip # noqa
     client.post(
         "/create-test-application",
-        json={"status": models.ApplicationStatus.DECLINED.value},
+        json={"status": models.ApplicationStatus.DECLINED},
     )
 
     declined_feedback = {
@@ -560,5 +560,5 @@ def test_application_declined_feedback(client):  # isort:skip # noqa
     }
 
     response = client.post("/applications/decline-feedback", json=declined_feedback)
-    assert response.json()["application"]["status"] == models.ApplicationStatus.DECLINED.value
+    assert response.json()["application"]["status"] == models.ApplicationStatus.DECLINED
     assert response.status_code == status.HTTP_200_OK

--- a/tests/test_lenders.py
+++ b/tests/test_lenders.py
@@ -34,7 +34,7 @@ lender_modified_not_valid = {
 }
 
 credit_product = {
-    "borrower_size": BorrowerSize.SMALL.value,
+    "borrower_size": BorrowerSize.SMALL,
     "lower_limit": 10000.00,
     "upper_limit": 50000.00,
     "interest_rate": 0.05,
@@ -43,7 +43,7 @@ credit_product = {
         "FINANCIAL_STATEMENT": True,
         "SUPPLIER_REGISTRATION_DOCUMENT": True,
     },
-    "type": CreditType.CREDIT_LINE.value,
+    "type": CreditType.CREDIT_LINE,
     "other_fees_total_amount": 100,
     "other_fees_description": "Processing fee",
     "more_info_url": "https://example.com",
@@ -51,7 +51,7 @@ credit_product = {
 }
 
 updated_credit_product = {
-    "borrower_size": BorrowerSize.SMALL.value,
+    "borrower_size": BorrowerSize.SMALL,
     "lower_limit": 100000.00,
     "upper_limit": 500000.00,
     "interest_rate": 0.05,
@@ -60,7 +60,7 @@ updated_credit_product = {
         "FINANCIAL_STATEMENT": True,
         "SUPPLIER_REGISTRATION_DOCUMENT": True,
     },
-    "type": CreditType.CREDIT_LINE.value,
+    "type": CreditType.CREDIT_LINE,
     "other_fees_total_amount": 100,
     "other_fees_description": "Processing fee",
     "more_info_url": "https://example.com",

--- a/tests/test_remove_data.py
+++ b/tests/test_remove_data.py
@@ -6,7 +6,7 @@ from tests.common.common_test_client import mock_ses_client  # isort:skip # noqa
 from tests.common.common_test_client import mock_cognito_client  # isort:skip # noqa
 from tests.common.common_test_client import app, client  # isort:skip # noqa
 
-application_payload = {"status": models.ApplicationStatus.PENDING.value}
+application_payload = {"status": models.ApplicationStatus.PENDING}
 
 
 def test_remove_data(client):  # noqa
@@ -14,7 +14,7 @@ def test_remove_data(client):  # noqa
     client.get("/set-test-application-as-dated/id/1")
     client.post(
         "/applications/1/update-test-application-status",
-        json={"status": models.ApplicationStatus.DECLINED.value},
+        json={"status": models.ApplicationStatus.DECLINED},
     )
 
     remove_dated_application_data()

--- a/tests/test_send_reminder.py
+++ b/tests/test_send_reminder.py
@@ -7,8 +7,8 @@ from tests.common.common_test_client import mock_ses_client  # isort:skip # noqa
 from tests.common.common_test_client import mock_cognito_client  # isort:skip # noqa
 from tests.common.common_test_client import app, client  # isort:skip # noqa
 
-application_payload = {"status": models.ApplicationStatus.PENDING.value}
-application_accepted_payload = {"status": models.ApplicationStatus.ACCEPTED.value}
+application_payload = {"status": models.ApplicationStatus.PENDING}
+application_accepted_payload = {"status": models.ApplicationStatus.ACCEPTED}
 
 
 def test_send_reminders_intro(client, mock_templated_email):  # noqa

--- a/tests/test_set_lapsed_applications.py
+++ b/tests/test_set_lapsed_applications.py
@@ -6,7 +6,7 @@ from tests.common.common_test_client import mock_ses_client  # isort:skip # noqa
 from tests.common.common_test_client import mock_cognito_client  # isort:skip # noqa
 from tests.common.common_test_client import app, client  # isort:skip # noqa
 
-application_payload = {"status": models.ApplicationStatus.PENDING.value}
+application_payload = {"status": models.ApplicationStatus.PENDING}
 
 
 def test_set_lapsed_applications(client):  # noqa

--- a/tests/test_statistic.py
+++ b/tests/test_statistic.py
@@ -12,7 +12,7 @@ from tests.common.common_test_client import app, client  # isort:skip # noqa
 OCP_user = {
     "email": "OCP_user@example.com",
     "name": "OCP_user@example.com",
-    "type": models.UserType.OCP.value,
+    "type": models.UserType.OCP,
 }
 lender = {
     "id": 1,
@@ -26,7 +26,7 @@ FI_user_with_lender = {
     "id": 2,
     "email": "FI_user_with_lender@example.com",
     "name": "Test FI with lender",
-    "type": models.UserType.FI.value,
+    "type": models.UserType.FI,
     "lender_id": 1,
 }
 

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -9,18 +9,18 @@ from tests.common.common_test_client import app, client  # isort:skip # noqa
 OCP_user = {
     "email": "OCP_test@noreply.open-contracting.org",
     "name": "OCP Test User",
-    "type": UserType.OCP.value,
+    "type": UserType.OCP,
 }
 FI_user = {
     "email": "fi_test@noreply.open-contracting.org",
     "name": "FI Test User",
-    "type": UserType.FI.value,
+    "type": UserType.FI,
 }
 
 test_user = {
     "email": "test@noreply.open-contracting.org",
     "name": "Test User",
-    "type": UserType.FI.value,
+    "type": UserType.FI,
 }
 
 


### PR DESCRIPTION
- chore: PR review #231, #197
- chore: Rename create_new_award to get_award
- chore: Use StrEnum instead of Enum, to avoid future programming errors when forgetting to call .value in some contexts
- test: Remove unnecessary .value for StrEnum enums
- chore: Reduce verticality of timestamp fields
- chore: Remove server_default from BorrowerDocumentBase.updated_at to be consistent with other updated_at fields (this only changes the CREATE TABLE, not INSERT/UPDATE)
- chore: Remove unnecessary .name for StrEnum enums
