### PR TITLE
Simplify and correct model fields

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -243,8 +243,8 @@ class CreditProductBase(SQLModel):
     interest_rate: str = Field(default="", nullable=False)
     additional_information: str = Field(default="", nullable=False)
     type: CreditType = Field(nullable=False)
-    borrower_types: dict[str, bool] = Field(default={}, sa_column=Column(JSON), nullable=False)
-    required_document_types: dict[str, bool] = Field(default={}, sa_column=Column(JSON), nullable=False)
+    borrower_types: dict[str, bool] = Field(default={}, sa_column=Column(JSON, nullable=False))
+    required_document_types: dict[str, bool] = Field(default={}, sa_column=Column(JSON))
     other_fees_total_amount: Decimal = Field(sa_column=Column(DECIMAL(precision=16, scale=2), nullable=False))
     other_fees_description: str = Field(default="", nullable=False)
     more_info_url: str = Field(default="", nullable=False)
@@ -303,7 +303,7 @@ class ApplicationBase(SQLModel):
     repayment_years: int | None = Field(nullable=True)
     repayment_months: int | None = Field(nullable=True)
     payment_start_date: datetime | None = Field(sa_column=Column(DateTime(timezone=False), nullable=True))
-    calculator_data: dict[str, Any] = Field(default={}, sa_column=Column(JSON), nullable=False)
+    calculator_data: dict[str, Any] = Field(default={}, sa_column=Column(JSON))
     borrower_credit_product_selected_at: datetime | None = Field(
         sa_column=Column(DateTime(timezone=True), nullable=True)
     )
@@ -313,13 +313,13 @@ class ApplicationBase(SQLModel):
     borrower_accepted_at: datetime | None = Field(sa_column=Column(DateTime(timezone=True), nullable=True))
     borrower_declined_at: datetime | None = Field(sa_column=Column(DateTime(timezone=True), nullable=True))
     overdued_at: datetime | None = Field(sa_column=Column(DateTime(timezone=True), nullable=True))
-    borrower_declined_preferences_data: dict[str, Any] = Field(default={}, sa_column=Column(JSON), nullable=False)
-    borrower_declined_data: dict[str, Any] = Field(default={}, sa_column=Column(JSON), nullable=False)
+    borrower_declined_preferences_data: dict[str, Any] = Field(default={}, sa_column=Column(JSON))
+    borrower_declined_data: dict[str, Any] = Field(default={}, sa_column=Column(JSON))
     lender_started_at: datetime | None = Field(sa_column=Column(DateTime(timezone=True), nullable=True))
-    secop_data_verification: dict[str, Any] = Field(default={}, sa_column=Column(JSON), nullable=False)
+    secop_data_verification: dict[str, Any] = Field(default={}, sa_column=Column(JSON))
     lender_approved_at: datetime | None = Field(sa_column=Column(DateTime(timezone=True), nullable=True))
-    lender_approved_data: dict[str, Any] = Field(default={}, sa_column=Column(JSON), nullable=False)
-    lender_rejected_data: dict[str, Any] | None = Field(default={}, sa_column=Column(JSON), nullable=False)
+    lender_approved_data: dict[str, Any] = Field(default={}, sa_column=Column(JSON))
+    lender_rejected_data: dict[str, Any] | None = Field(default={}, sa_column=Column(JSON))
     lender_rejected_at: datetime | None = Field(sa_column=Column(DateTime(timezone=True), nullable=True))
     borrower_uploaded_contract_at: datetime | None = Field(sa_column=Column(DateTime(timezone=True), nullable=True))
     lender_completed_at: datetime | None = Field(sa_column=Column(DateTime(timezone=True), nullable=True))
@@ -549,7 +549,7 @@ class BorrowerBase(SQLModel):
     type: str = Field(default="")
     sector: str = Field(default="")
     size: BorrowerSize = Field(default=BorrowerSize.NOT_INFORMED, nullable=True)
-    missing_data: dict[str, bool] = Field(default={}, sa_column=Column(JSON), nullable=False)
+    missing_data: dict[str, bool] = Field(default={}, sa_column=Column(JSON))
     created_at: datetime | None = Field(
         sa_column=Column(DateTime(timezone=True), nullable=False, default=datetime.utcnow(), server_default=func.now())
     )
@@ -560,7 +560,7 @@ class BorrowerBase(SQLModel):
 
 
 class Borrower(BorrowerBase, ActiveRecordMixin, table=True):
-    source_data: dict[str, Any] = Field(default={}, sa_column=Column(JSON), nullable=False)
+    source_data: dict[str, Any] = Field(default={}, sa_column=Column(JSON))
     status: BorrowerStatus = Field(default=BorrowerStatus.ACTIVE, nullable=True)
     applications: list["Application"] | None = Relationship(back_populates="borrower")
     awards: list["Award"] = Relationship(back_populates="borrower")
@@ -604,7 +604,7 @@ class AwardBase(SQLModel):
     award_currency: str = Field(default="COP", description="ISO 4217 currency code")
     contractperiod_startdate: datetime | None = Field(sa_column=Column(DateTime(timezone=False), nullable=True))
     contractperiod_enddate: datetime | None = Field(sa_column=Column(DateTime(timezone=False), nullable=True))
-    payment_method: dict[str, Any] = Field(default={}, sa_column=Column(JSON), nullable=False)
+    payment_method: dict[str, Any] = Field(default={}, sa_column=Column(JSON))
     buyer_name: str = Field(default="")
     source_url: str = Field(default="")
     entity_code: str = Field(default="")
@@ -614,14 +614,14 @@ class AwardBase(SQLModel):
     procurement_method: str = Field(default="")
     contracting_process_id: str = Field(default="")
     procurement_category: str = Field(default="")
-    missing_data: dict[str, bool] = Field(default={}, sa_column=Column(JSON), nullable=False)
+    missing_data: dict[str, bool] = Field(default={}, sa_column=Column(JSON))
 
 
 class Award(AwardBase, ActiveRecordMixin, table=True):
     applications: list["Application"] | None = Relationship(back_populates="award")
     borrower: Borrower = Relationship(back_populates="awards")
-    source_data_contracts: dict[str, Any] = Field(default={}, sa_column=Column(JSON), nullable=False)
-    source_data_awards: dict[str, Any] = Field(default={}, sa_column=Column(JSON), nullable=False)
+    source_data_contracts: dict[str, Any] = Field(default={}, sa_column=Column(JSON))
+    source_data_awards: dict[str, Any] = Field(default={}, sa_column=Column(JSON))
     created_at: datetime | None = Field(
         sa_column=Column(DateTime(timezone=True), nullable=False, default=datetime.utcnow(), server_default=func.now())
     )

--- a/app/models.py
+++ b/app/models.py
@@ -571,7 +571,7 @@ class LenderBase(SQLModel):
     email_group: str = Field(default="")
     type: str = Field(default="")
     sla_days: int | None
-    logo_filename: str = Field(default="")
+    logo_filename: str = Field(default="", nullable=True)
 
 
 class Lender(LenderBase, ActiveRecordMixin, table=True):


### PR DESCRIPTION
- chore(sqlmodel): Enum is supported since sqlmodel 0.0.7. SQLAlchemy Column() has nullable=True by default.
- fix: Set logo_filename as nullable, like on the server
- chore: nullable as a sibling to sa_column has no effect #235. borrower_types is not nullable on the server, so set nullable=False.
