### PR TITLE
SQLModel upgrade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,12 @@ jobs:
       - name: Run checks and tests
         env:
           TEST_DATABASE_URL: postgresql://postgres:postgres@localhost:${{ job.services.postgres.ports[5432] }}/postgres
-        run: pytest -W error --cov app
+        # Need to upgrade to Pydantic 2.
+        run: pytest -W error -W ignore::DeprecationWarning --cov app
       - env:
           TEST_SETTINGS: True
-        run: pytest -W error settings_tests/test_settings.py
+        # Need to upgrade to Pydantic 2.
+        run: pytest -W error -W ignore::DeprecationWarning settings_tests/test_settings.py
       - env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: coveralls --service=github

--- a/app/models.py
+++ b/app/models.py
@@ -90,7 +90,7 @@ class ActiveRecordMixin:
         for key, value in data.items():
             setattr(self, key, value)
         if hasattr(self, "missing_data"):
-            self.missing_data = _get_missing_data_keys(self.dict())
+            self.missing_data = _get_missing_data_keys(self.model_dump())
 
         session.add(self)
         session.flush()

--- a/app/routers/lenders.py
+++ b/app/routers/lenders.py
@@ -37,13 +37,13 @@ async def create_lender(
     with transaction_session(session):
         try:
             # Create a Lender instance without the credit_product data
-            db_lender = models.Lender(**payload.dict(exclude={"credit_products"}))
+            db_lender = models.Lender(**payload.model_dump(exclude={"credit_products"}))
             session.add(db_lender)
 
             # Create a CreditProduct instance for each credit product and add it to the lender
             if payload.credit_products:
                 for cp in payload.credit_products:
-                    credit_product = models.CreditProduct(**cp.dict(), lender=db_lender)
+                    credit_product = models.CreditProduct(**cp.model_dump(), lender=db_lender)
                     session.add(credit_product)
 
             session.flush()
@@ -77,7 +77,7 @@ async def create_credit_products(
     with transaction_session(session):
         lender = get_object_or_404(session, models.Lender, "id", lender_id)
 
-        return models.CreditProduct.create(session, **credit_product.dict(), lender=lender)
+        return models.CreditProduct.create(session, **credit_product.model_dump(), lender=lender)
 
 
 @router.get(

--- a/app/routers/users.py
+++ b/app/routers/users.py
@@ -38,7 +38,7 @@ async def create_user(
     """
     with transaction_session(session):
         try:
-            user = models.User(**payload.dict())
+            user = models.User(**payload.model_dump())
             user.created_at = datetime.now()
             session.add(user)
             cognito_response = client.admin_create_user(payload.email, payload.name)

--- a/app/util.py
+++ b/app/util.py
@@ -115,7 +115,7 @@ def get_modified_data_fields(application: models.Application, session: Session) 
                 }
 
     return models.ApplicationWithRelations(
-        **application.dict(),
+        **application.model_dump(),
         award=application.award,
         borrower=application.borrower,
         lender=application.lender,

--- a/requirements.txt
+++ b/requirements.txt
@@ -87,7 +87,7 @@ pyasn1==0.5.0
     # via
     #   python-jose
     #   rsa
-pydantic==1.10.7
+pydantic==1.10.13
     # via
     #   -r requirements.in
     #   fastapi
@@ -138,14 +138,12 @@ sniffio==1.3.0
     #   anyio
     #   httpcore
     #   httpx
-sqlalchemy[postgresql]==1.4.41
+sqlalchemy[postgresql]==2.0.23
     # via
     #   -r requirements.in
     #   alembic
     #   sqlmodel
-sqlalchemy2-stubs==0.0.2a34
-    # via sqlmodel
-sqlmodel==0.0.8
+sqlmodel==0.0.14
     # via -r requirements.in
 starlette==0.27.0
     # via fastapi
@@ -161,7 +159,7 @@ typing-extensions==4.5.0
     #   mypy-boto3-cognito-idp
     #   mypy-boto3-ses
     #   pydantic
-    #   sqlalchemy2-stubs
+    #   sqlalchemy
     #   typer
 tzdata==2023.3
     # via pandas

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -198,7 +198,7 @@ pycodestyle==2.10.0
     # via flake8
 pycparser==2.21
     # via cffi
-pydantic==1.10.7
+pydantic==1.10.13
     # via
     #   -r requirements.txt
     #   fastapi
@@ -279,9 +279,7 @@ s3transfer==0.6.1
     #   -r requirements.txt
     #   boto3
 sentry-sdk[fastapi]==1.23.1
-    # via
-    #   -r requirements.txt
-    #   sentry-sdk
+    # via -r requirements.txt
 shellingham==1.5.0.post1
     # via
     #   -r requirements.txt
@@ -298,17 +296,12 @@ sniffio==1.3.0
     #   anyio
     #   httpcore
     #   httpx
-sqlalchemy[postgresql]==1.4.41
+sqlalchemy[postgresql]==2.0.23
     # via
     #   -r requirements.txt
     #   alembic
-    #   sqlalchemy
     #   sqlmodel
-sqlalchemy2-stubs==0.0.2a34
-    # via
-    #   -r requirements.txt
-    #   sqlmodel
-sqlmodel==0.0.8
+sqlmodel==0.0.14
     # via -r requirements.txt
 starlette==0.27.0
     # via
@@ -321,9 +314,7 @@ toolz==0.12.0
 transifex-python==3.4.0
     # via -r requirements.txt
 typer[all]==0.9.0
-    # via
-    #   -r requirements.txt
-    #   typer
+    # via -r requirements.txt
 types-awscrt==0.19.17
     # via botocore-stubs
 types-pyyaml==6.0.12.10
@@ -338,7 +329,7 @@ typing-extensions==4.5.0
     #   mypy-boto3-cognito-idp
     #   mypy-boto3-ses
     #   pydantic
-    #   sqlalchemy2-stubs
+    #   sqlalchemy
     #   typer
 tzdata==2023.3
     # via

--- a/tests/protected_routes/users_test.py
+++ b/tests/protected_routes/users_test.py
@@ -18,7 +18,7 @@ async def create_test_user_headers(
     session: Session = Depends(get_db),
     client: CognitoClient = Depends(dependencies.get_cognito_client),
 ):
-    user = User(**payload.dict())
+    user = User(**payload.model_dump())
 
     cognito_response = client.admin_create_user(payload.email, payload.name)
     user.external_id = cognito_response["User"]["Username"]


### PR DESCRIPTION
Since I can't get #238 passing, we can start with just SQLModel (and disable deprecation warnings, because the older versions of FastAPI and/or Pydantic call deprecated methods in SQLModel).

Before merging, it might be worthwhile to run mypy and review the new errors, compared to those in #217 .