### PR TITLE
chore: Raise SourceFormatError instead of SkippedAwardError when outside handle_skipped_award

### DIFF
--- a/app/commands.py
+++ b/app/commands.py
@@ -12,7 +12,7 @@ import app.utils.statistics as statistics_utils
 from app import mail, models, util
 from app.aws import sesClient
 from app.db import get_db, handle_skipped_award, rollback_on_error
-from app.exceptions import SkippedAwardError
+from app.exceptions import SkippedAwardError, SourceFormatError
 from app.settings import app_settings
 from app.sources import colombia as data_access
 
@@ -147,7 +147,7 @@ def _get_awards_from_data_source(
 
         for entry in awards_response_json:
             if not all(key in entry for key in ("id_del_portafolio", "nit_del_proveedor_adjudicado")):
-                raise SkippedAwardError(
+                raise SourceFormatError(
                     "Source contract is missing required fields",
                     url=awards_response.url,
                     data={"response": awards_response_json},

--- a/app/exceptions.py
+++ b/app/exceptions.py
@@ -2,6 +2,10 @@ class CredereError(Exception):
     """Base class for exceptions from within this application"""
 
 
+class SourceFormatError(CredereError):
+    """Raised if the response format of the data source has changed"""
+
+
 class SkippedAwardError(CredereError):
     """Raised if an award needs to be skipped due to a data quality issue"""
 


### PR DESCRIPTION
fixes #311

This fix assumes that we don't want to do the following instead:

> Or, if we want to allow processing to continue, we need to add handle_skipped_award inside the for-loop in _get_awards_from_data_source. That said, if keys are missing, it might be a sign that the response format has changed, in which case we would expect all awards to fail.