### PR TITLE
fix: Require admin user for users/{user_id}, closes #413

### DIFF
--- a/app/routers/users.py
+++ b/app/routers/users.py
@@ -270,6 +270,7 @@ def forgot_password(
 )
 async def get_user(
     user_id: int,
+    admin: models.User = Depends(dependencies.get_admin_user),
     session: Session = Depends(get_db),
 ) -> models.User:
     """

--- a/tests/routers/test_users.py
+++ b/tests/routers/test_users.py
@@ -19,11 +19,11 @@ def test_create_and_get_user(client, admin_header, lender_header, user_payload):
     assert response.json()["name"] == user_payload["name"]
 
     # fetch second user since the first one is the OCP user created for headers
-    response = client.get("/users/2")
+    response = client.get("/users/2", headers=admin_header)
     assert_ok(response)
 
     # try to get a non-existing user
-    response = client.get("/users/200")
+    response = client.get("/users/200", headers=admin_header)
     assert response.status_code == status.HTTP_404_NOT_FOUND
     assert response.json() == {"detail": _("%(model_name)s not found", model_name="User")}
 


### PR DESCRIPTION
I think in the frontend this route is only used by admins.