### PR TITLE
test: Seed fixture timestamps as timezone-aware to fix tz-dependent f…

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ import os
 import uuid
 from collections.abc import Generator
 from contextlib import contextmanager
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -331,7 +331,7 @@ def borrower(session):
         },
         status=models.BorrowerStatus.ACTIVE,
         # Timestamps
-        created_at=datetime.utcnow(),
+        created_at=datetime.now(UTC),
         updated_at="2023-06-22T17:48:05.381251",
     )
     session.commit()
@@ -382,7 +382,7 @@ def application_payload(application_uuid, award, borrower):
         "award_id": award.id,
         "borrower": borrower,
         # Timestamps
-        "created_at": datetime.utcnow(),
+        "created_at": datetime.now(UTC),
         "updated_at": "2023-06-26T03:14:31.572553+00:00",
     }
 
@@ -433,7 +433,7 @@ def submitted_application_external_onboarding(
         status=models.ApplicationStatus.SUBMITTED,
         credit_product_id=credit_product_external_onboarding.id,
         lender_id=lender_external_onboarding.id,
-        borrower_submitted_at=datetime.utcnow(),
+        borrower_submitted_at=datetime.now(UTC),
     )
     session.commit()
     return instance


### PR DESCRIPTION
…ailures

The command boundary tests build timestamps with datetime.now(obj.tz), where obj.tz is created_at.tzinfo, mirroring production's datetime.now(application.created_at.tzinfo). The fixtures seeded created_at with naive datetime.utcnow(), and with expire_on_commit=False the object is never reloaded, so tzinfo was None and datetime.now(None) produced a naive local-wallclock value. Postgres then interpreted that naive value using its own session timezone on insert into timestamptz columns, shifting the stored instant when the server tz differed from the OS tz (e.g. America/Asuncion vs UTC) by far more than the tests' ±5s boundary margin, flipping the boundary cases.

Seed created_at (and borrower_submitted_at) as aware datetime.now(UTC), matching what records read back from the DB look like in production, so obj.tz is a real zone and the comparisons are timezone-independent.